### PR TITLE
Add initDependencies stub

### DIFF
--- a/Addon.php
+++ b/Addon.php
@@ -58,4 +58,9 @@ abstract class LiamW_AlterEgoDetector_Addon
 				break;
 		}
 	}
+	
+	// This is a stub to allow the upgrade to go smoothly
+	public static function initDependencies(XenForo_Dependencies_Abstract $dependencies, array $data)
+	{
+	}
 }


### PR DESCRIPTION
On removing a listener, there is a brief period between when the file is updated and the addon refreshes the listener cache.

By adding a stub, this false positive can be avoided and allow the upgrade to occur without requiring to restart it.
