### PR TITLE
Allow Cookie lifespan to be configurable.

### DIFF
--- a/Extend/ControllerPublic/Login.php
+++ b/Extend/ControllerPublic/Login.php
@@ -72,7 +72,7 @@ class LiamW_AlterEgoDetector_Extend_ControllerPublic_Login extends XFCP_LiamW_Al
 					{
 						$bypassCheck = false;
 						// set a new cookie as the old account was deleted
-						$spamModel->setCookieValue($originalUserId);
+						$spamModel->setCookieValue($originalUserId, $options->aed_cookie_lifespan * 2592000);
 					}
 					if (!$bypassCheck)
 					{
@@ -87,7 +87,7 @@ class LiamW_AlterEgoDetector_Extend_ControllerPublic_Login extends XFCP_LiamW_Al
 		else if (!$bypassCheck)
 		{
 			// SET COOKIE
-			$spamModel->setCookieValue($originalUserId);
+			$spamModel->setCookieValue($originalUserId, $options->aed_cookie_lifespan * 2592000);
 		}
 
 		if (!$aeDetected && !$bypassCheck)

--- a/Extend/Model/SpamPrevention.php
+++ b/Extend/Model/SpamPrevention.php
@@ -272,7 +272,7 @@ class LiamW_AlterEgoDetector_Extend_Model_SpamPrevention extends XFCP_LiamW_Alte
 
 		if ($options->aedredeploycookie)
 		{
-			$this->setCookieValue($newUserId);
+			$this->setCookieValue($newUserId, $options->aed_cookie_lifespan * 2592000);
 		}
 	}
 

--- a/addon-liam_ae_detector.xml
+++ b/addon-liam_ae_detector.xml
@@ -33,6 +33,12 @@
     <optiongroups>
         <group group_id="aed_debugoptions" display_order="100000" debug_only="1"/>
         <group group_id="aed_options" display_order="50000" debug_only="0"/>
+    <option option_id="aed_cookie_lifespan" edit_format="spinbox" data_type="positive_integer" can_backup="1">
+      <default_value>12</default_value>
+      <edit_format_params></edit_format_params>
+      <sub_options></sub_options>
+      <relation group_id="aed_options" display_order="10"/>
+    </option>
         <option option_id="aedcheckbanned" edit_format="onoff" data_type="boolean" can_backup="1">
             <default_value></default_value>
             <edit_format_params></edit_format_params>
@@ -227,6 +233,8 @@
         <phrase title="option_aedusername" version_id="1" version_string="1.0"><![CDATA[Username]]></phrase>
         <phrase title="option_aedusername_explain" version_id="1" version_string="1.0">
             <![CDATA[Username of the posting user. This is required.]]></phrase>
+        <phrase title="option_aed_cookie_lifespan" version_id="10405" version_string="1.4.5"><![CDATA[Cookie Lifespan]]></phrase>
+        <phrase title="option_aed_cookie_lifespan_explain" version_id="10405" version_string="1.4.5"><![CDATA[The Lifespan of the cookie in months.]]></phrase>
         <phrase title="option_group_aed_debugoptions" version_id="1" version_string="1.0">
             <![CDATA[Alter Ego Detector Debugging Options]]></phrase>
         <phrase title="option_group_aed_debugoptions_description" version_id="1" version_string="1.0">


### PR DESCRIPTION
Ref: https://xenforo.com/community/threads/alter-ego-detector.60972/page-15#post-899281

Note I used; determines a month as; 30 \* (1 day in seconds) from punching numbers into google.
